### PR TITLE
Overføringer for 2021

### DIFF
--- a/nais/dev-gcp.json
+++ b/nais/dev-gcp.json
@@ -26,6 +26,7 @@
     "AZURE_APP_TOKEN_ENDPOINT": "https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/oauth2/v2.0/token",
     "AZURE_V2_JWKS_URI": "https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/discovery/v2.0/keys",
     "AZURE_V2_ISSUER": "https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/v2.0",
-    "SEND_STATISTIKK": "enabled"
+    "SEND_STATISTIKK": "enabled",
+    "KORONA_BEHANDLING": "enabled"
   }
 }

--- a/nais/dev-gcp.json
+++ b/nais/dev-gcp.json
@@ -26,7 +26,6 @@
     "AZURE_APP_TOKEN_ENDPOINT": "https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/oauth2/v2.0/token",
     "AZURE_V2_JWKS_URI": "https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/discovery/v2.0/keys",
     "AZURE_V2_ISSUER": "https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/v2.0",
-    "SEND_STATISTIKK": "enabled",
-    "OVERFORING_API": "enabled"
+    "SEND_STATISTIKK": "enabled"
   }
 }

--- a/src/main/kotlin/no/nav/omsorgspenger/App.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/App.kt
@@ -68,6 +68,9 @@ internal fun RapidsConnection.registerApplicationContext(applicationContext: App
         rapidsConnection = this,
         behovssekvensRepository = applicationContext.behovssekvensRepository
     )
+    registerOverføreKoronaOmsorgsdager(
+        applicationContext = applicationContext
+    )
     register(object : RapidsConnection.StatusListener {
         override fun onStartup(rapidsConnection: RapidsConnection) {
             applicationContext.start()
@@ -79,13 +82,13 @@ internal fun RapidsConnection.registerApplicationContext(applicationContext: App
 }
 
 internal fun RapidsConnection.registerOverføreKoronaOmsorgsdager(applicationContext: ApplicationContext) {
-    val behandlingEnabled = applicationContext.env.hentOptionalEnv("KORONA_BEHANDLING") == "enabled"
+    val enableBehandling = applicationContext.env.hentOptionalEnv("KORONA_BEHANDLING") == "enabled"
     InitierOverføreKoronaOmsorgsdager(
         rapidsConnection = this,
         behovssekvensRepository = applicationContext.behovssekvensRepository,
-        enableBehandling = behandlingEnabled
+        enableBehandling = enableBehandling
     )
-    if (behandlingEnabled) {
+    if (enableBehandling) {
         BehandleOverføreKoronaOmsorgsdager(
             rapidsConnection = this,
             behovssekvensRepository = applicationContext.behovssekvensRepository

--- a/src/main/kotlin/no/nav/omsorgspenger/App.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/App.kt
@@ -16,7 +16,6 @@ import no.nav.omsorgspenger.overføringer.rivers.BehandleOverføringAvOmsorgsdag
 import no.nav.omsorgspenger.overføringer.rivers.InitierOverføringAvOmsorgsdager
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.ktor.auth.*
-import io.ktor.client.HttpClient
 import io.ktor.http.*
 import io.ktor.request.*
 import io.ktor.response.*
@@ -29,7 +28,6 @@ import no.nav.omsorgspenger.koronaoverføringer.rivers.InitierOverføreKoronaOms
 import no.nav.omsorgspenger.koronaoverføringer.rivers.PubliserOverføreKoronaOmsorgsdager
 import no.nav.omsorgspenger.midlertidigalene.rivers.InitierMidlertidigAlene
 import no.nav.omsorgspenger.overføringer.apis.OverføringerApi
-import no.nav.omsorgspenger.overføringer.apis.TilgangsstyringRestClient
 import org.slf4j.event.Level
 
 fun main() {
@@ -81,19 +79,23 @@ internal fun RapidsConnection.registerApplicationContext(applicationContext: App
 }
 
 internal fun RapidsConnection.registerOverføreKoronaOmsorgsdager(applicationContext: ApplicationContext) {
+    val behandlingEnabled = applicationContext.env.hentOptionalEnv("KORONA_BEHANDLING") == "enabled"
     InitierOverføreKoronaOmsorgsdager(
         rapidsConnection = this,
-        behovssekvensRepository = applicationContext.behovssekvensRepository
-    )
-    BehandleOverføreKoronaOmsorgsdager(
-        rapidsConnection = this,
-        behovssekvensRepository = applicationContext.behovssekvensRepository
-    )
-    PubliserOverføreKoronaOmsorgsdager(
-        rapidsConnection = this,
         behovssekvensRepository = applicationContext.behovssekvensRepository,
-        formidlingService = applicationContext.formidlingService
+        enableBehandling = behandlingEnabled
     )
+    if (behandlingEnabled) {
+        BehandleOverføreKoronaOmsorgsdager(
+            rapidsConnection = this,
+            behovssekvensRepository = applicationContext.behovssekvensRepository
+        )
+        PubliserOverføreKoronaOmsorgsdager(
+            rapidsConnection = this,
+            behovssekvensRepository = applicationContext.behovssekvensRepository,
+            formidlingService = applicationContext.formidlingService
+        )
+    }
 }
 
 internal fun Application.omsorgspengerRammemeldinger(applicationContext: ApplicationContext) {

--- a/src/main/kotlin/no/nav/omsorgspenger/koronaoverføringer/ManuellVurdering.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/koronaoverføringer/ManuellVurdering.kt
@@ -11,7 +11,7 @@ internal object ManuellVurdering {
         behovet: OverføreKoronaOmsorgsdagerMelding.Behovet
     ) : Boolean {
         val grunnetJobberIkkeINorge = !behovet.jobberINorge.also { if (it) {
-            logger.warn("Må vurderes manuelt grunnet vedtak om utvidet rett vi ikke kunne verifisere.")
+            logger.warn("Må vurderes manuelt grunnet at personen ikke jobber i Norge.")
         }}
         val grunnetPeriode = !behovet.periode.erStøttetPeriode().also { if(it) {
             logger.warn("Må vurderes manuelt grunnet at overføringen gjelder for perioden ${behovet.periode} som ikke støttes.")

--- a/src/main/kotlin/no/nav/omsorgspenger/overføringer/meldinger/OverføreOmsorgsdagerMelding.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/overføringer/meldinger/OverføreOmsorgsdagerMelding.kt
@@ -44,8 +44,6 @@ internal object OverføreOmsorgsdagerMelding :
     }
 
     override fun hentBehov(packet: JsonMessage) = Relasjon.valueOf(packet[BehovKeys.Relasjon].asText()).let { relasjon ->
-
-
         Behovet(
             barn = (packet[BehovKeys.Barn] as ArrayNode).map { it.somBarn() },
             overførerFra = packet[BehovKeys.OverførerFra].textValue(),

--- a/src/test/kotlin/no/nav/omsorgspenger/koronaoverføringer/rivers/BehandleKoronaOverføringerTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/koronaoverføringer/rivers/BehandleKoronaOverføringerTest.kt
@@ -18,7 +18,10 @@ internal class BehandleKoronaOverføringerTest(
     dataSource: DataSource) {
     private val rapid = TestRapid().apply {
         this.registerOverføreKoronaOmsorgsdager(
-            TestApplicationContextBuilder(dataSource.cleanAndMigrate()).build()
+            TestApplicationContextBuilder(
+                dataSource = dataSource.cleanAndMigrate(),
+                additionalEnv = mapOf("KORONA_BEHANDLING" to "enabled")
+            ).build()
         )
     }
 

--- a/src/test/kotlin/no/nav/omsorgspenger/koronaoverføringer/rivers/KoronaOverføringPåVentTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/koronaoverføringer/rivers/KoronaOverføringPåVentTest.kt
@@ -1,0 +1,72 @@
+package no.nav.omsorgspenger.koronaoverføringer.rivers
+
+import no.nav.helse.rapids_rivers.testsupport.TestRapid
+import no.nav.omsorgspenger.Periode
+import no.nav.omsorgspenger.registerOverføreKoronaOmsorgsdager
+import no.nav.omsorgspenger.testutils.DataSourceExtension
+import no.nav.omsorgspenger.testutils.IdentitetsnummerGenerator
+import no.nav.omsorgspenger.testutils.TestApplicationContextBuilder
+import no.nav.omsorgspenger.testutils.cleanAndMigrate
+import no.nav.omsorgspenger.testutils.sisteMeldingSomJSONObject
+import no.nav.omsorgspenger.testutils.ventPå
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import javax.sql.DataSource
+import kotlin.test.assertEquals
+
+@ExtendWith(DataSourceExtension::class)
+internal class KoronaOverføringPåVentTest(
+    dataSource: DataSource) {
+    private val rapid = TestRapid().apply {
+        this.registerOverføreKoronaOmsorgsdager(
+            TestApplicationContextBuilder(
+                dataSource = dataSource.cleanAndMigrate(),
+                additionalEnv = mapOf("KORONA_BEHANDLING" to "disabled")
+            ).build()
+        )
+    }
+
+    @BeforeEach
+    fun reset() {
+        rapid.reset()
+    }
+
+    @Test
+    fun `Søknad for 2020 blir sendt som Gosysoppgave`() {
+        val fra = IdentitetsnummerGenerator.identitetsnummer()
+        val til = IdentitetsnummerGenerator.identitetsnummer()
+
+        val (id, behovssekvens) = behovssekvensOverføreKoronaOmsorgsdager(
+            fra = fra,
+            til = til,
+            omsorgsdagerÅOverføre = 10,
+            periode = Periode("2020-06-01/2020-12-31"),
+            journalpostIder = listOf("12345")
+        )
+        rapid.sendTestMessage(behovssekvens)
+        rapid.ventPå(1)
+        rapid.sisteMeldingSomJSONObject().assertGosysJournalføringsoppgave(
+            behovssekvensId = id,
+            fra = fra,
+            til = til,
+            journalpostId = "12345"
+        )
+    }
+
+    @Test
+    fun `Søknad for 2021 blir ikke behandlet`() {
+        val fra = IdentitetsnummerGenerator.identitetsnummer()
+        val til = IdentitetsnummerGenerator.identitetsnummer()
+
+        val (_, behovssekvens) = behovssekvensOverføreKoronaOmsorgsdager(
+            fra = fra,
+            til = til,
+            omsorgsdagerÅOverføre = 10,
+            periode = Periode("2021-01-01/2021-12-31"),
+            journalpostIder = listOf("12345")
+        )
+        rapid.sendTestMessage(behovssekvens)
+        assertEquals(0, rapid.inspektør.size)
+    }
+}

--- a/src/test/kotlin/no/nav/omsorgspenger/overføringer/OverføringerPåVentTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/overføringer/OverføringerPåVentTest.kt
@@ -1,0 +1,38 @@
+package no.nav.omsorgspenger.overføringer
+
+import no.nav.helse.rapids_rivers.testsupport.TestRapid
+import no.nav.omsorgspenger.registerApplicationContext
+import no.nav.omsorgspenger.testutils.DataSourceExtension
+import no.nav.omsorgspenger.testutils.TestApplicationContextBuilder
+import no.nav.omsorgspenger.testutils.cleanAndMigrate
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.LocalDate
+import javax.sql.DataSource
+import kotlin.test.assertEquals
+
+@ExtendWith(DataSourceExtension::class)
+internal class OverføringerPåVentTest(
+    dataSource: DataSource) {
+    private val rapid = TestRapid().apply {
+        this.registerApplicationContext(
+            TestApplicationContextBuilder(dataSource.cleanAndMigrate()).build()
+        )
+    }
+
+    @BeforeEach
+    fun reset() {
+        rapid.reset()
+    }
+
+    @Test
+    fun `Overføring mottatt i 2021 behandles ikke`() {
+        val (_, behovssekvens) = behovssekvensOverføreOmsorgsdager(
+            mottaksdato = LocalDate.parse("2021-01-01"),
+            barn = listOf(overføreOmsorgsdagerBarn())
+        )
+        rapid.sendTestMessage(behovssekvens)
+        assertEquals(0, rapid.inspektør.size)
+    }
+}

--- a/src/test/kotlin/no/nav/omsorgspenger/overføringer/TestVerktøy.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/overføringer/TestVerktøy.kt
@@ -41,7 +41,7 @@ internal fun behovssekvensOverføreOmsorgsdager(
     overføringTil: Identitetsnummer = identitetsnummer(),
     omsorgsdagerTattUtIÅr: Int = 0,
     omsorgsdagerÅOverføre: Int = 10,
-    mottaksdato: LocalDate = LocalDate.now(),
+    mottaksdato: LocalDate = LocalDate.parse("2020-12-15"),
     barn: List<OverføreOmsorgsdagerBehov.Barn> = emptyList(),
     jobberINorge: Boolean = true,
     relasjon: OverføreOmsorgsdagerBehov.Relasjon = OverføreOmsorgsdagerBehov.Relasjon.NåværendeEktefelle,

--- a/src/test/kotlin/no/nav/omsorgspenger/statistikk/StatistikkServiceTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/statistikk/StatistikkServiceTest.kt
@@ -28,7 +28,7 @@ internal class StatistikkServiceTest {
     }
 
     @Test
-    internal fun name() {
+    fun `Sending av statistikkmeldinger`() {
         val meldinger = mutableListOf<ProducerRecord<String, String>>()
 
         every { kafkaProducer.send(capture(meldinger)) }.returns(CompletableFuture.completedFuture(null))

--- a/src/test/kotlin/no/nav/omsorgspenger/testutils/TestApplicationContextBuilder.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/testutils/TestApplicationContextBuilder.kt
@@ -20,7 +20,8 @@ import javax.sql.DataSource
 
 internal fun TestApplicationContextBuilder(
     dataSource: DataSource,
-    wireMockServer: WireMockServer? = null
+    wireMockServer: WireMockServer? = null,
+    additionalEnv: Map<String, String> = emptyMap()
 ) = ApplicationContext.Builder(
     accessTokenClient = mockk<AccessTokenClient>().also {
         every { it.getAccessToken(any()) }.returns(AccessTokenResponse(accessToken = "foo", expiresIn = 1000, tokenType = "Bearer"))
@@ -51,7 +52,7 @@ internal fun TestApplicationContextBuilder(
             "AZURE_APP_CLIENT_ID" to "omsorgspenger-rammemeldinger",
             "TILGANGSSTYRING_URL" to wireMockServer.tilgangApiBaseUrl()
         )
-    }.plus("OVERFORING_API" to "enabled")
+    }.plus(additionalEnv)
 )
 
 internal fun DataSource.cleanAndMigrate() = this.also {


### PR DESCRIPTION
- Ordinær overføring settes på vent om det er mottatt i 2021, behandler kun ferdig de vi mottar ila. 2020
- Koronaoverføringer for tidligere perioder (i 2020) blir det alltid opprettet Gosysoppgaver for
- Koronaoverføringer for 2021 settes på vent
- Behandling av koronaoverføringer for 2021 kan enables, kun enable for dev per nå.