### PR TITLE
Utvidet visning-API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,11 +8,11 @@ val mockkVersion = "1.10.5"
 val ulidVersion = "8.2.0"
 val ktorVersion = "1.5.0"
 val assertjVersion = "3.19.0"
-val dusseldorfVersion = "1.5.0.ae98b7c"
+val dusseldorfVersion = "1.5.1.9b0fee0"
 val schemaValidatorVersion = "1.0.47"
 
 // Database
-val flywayVersion = "7.5.1"
+val flywayVersion = "7.5.2"
 val hikariVersion = "4.0.1"
 val kotliqueryVersion = "1.3.1"
 val postgresVersion = "42.2.18"


### PR DESCRIPTION
- saksnummer & identitetsnummer for det aktuelle oppslaget i response i tillegg til listene for `gitt` og `fått`
- 404 response om saksnummeret ikke finnes