### PR TITLE
Meldinger for opphøring av ordinære & koronaoverføringer

### DIFF
--- a/src/main/kotlin/no/nav/omsorgspenger/koronaoverføringer/formidling/Maler.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/koronaoverføringer/formidling/Maler.kt
@@ -27,6 +27,19 @@ internal class GittDager(
     }()
 }
 
+internal class GittDagerOpphørt(
+    val til: OverføreKoronaOmsorgsdagerPersonopplysningerMelding.Personopplysninger,
+    val fraOgMed: LocalDate
+) : Melding {
+    override val mal = "KORONA_OVERFORE_GITT_DAGER_OPPHORT"
+    override val data = {
+        JSONObject().also { root ->
+            root.put("fraOgMed", "$fraOgMed")
+            root.put("til", til.somJSONObject())
+        }.toString()
+    }()
+}
+
 internal class MottattDager(
     val fra: OverføreKoronaOmsorgsdagerPersonopplysningerMelding.Personopplysninger,
     val mottaksdato: LocalDate,
@@ -40,6 +53,19 @@ internal class MottattDager(
                 "gjelderTilOgMed" to "${overføring.periode.tom}",
                 "antallDager" to overføring.antallDager
             ).let { JSONArray().put(it)})
+            root.put("fra", fra.somJSONObject())
+        }.toString()
+    }()
+}
+
+internal class MottattDagerOpphørt(
+    val fra: OverføreKoronaOmsorgsdagerPersonopplysningerMelding.Personopplysninger,
+    val fraOgMed: LocalDate
+) : Melding {
+    override val mal = "KORONA_OVERFORE_MOTTATT_DAGER_OPPHORT"
+    override val data = {
+        JSONObject().also { root ->
+            root.put("fraOgMed", "$fraOgMed")
             root.put("fra", fra.somJSONObject())
         }.toString()
     }()

--- a/src/main/kotlin/no/nav/omsorgspenger/overføringer/formidling/Maler.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/overføringer/formidling/Maler.kt
@@ -32,6 +32,19 @@ internal class GittDager(
     }()
 }
 
+internal class GittDagerOpphørt(
+    val til: Personopplysninger,
+    val fraOgMed: LocalDate
+) : Melding {
+    override val mal = "OVERFORE_GITT_DAGER_OPPHORT"
+    override val data = {
+        JSONObject().also { root ->
+            root.put("fraOgMed", "$fraOgMed")
+            root.put("til", til.somJSONObject())
+        }.toString()
+    }()
+}
+
 internal class MottattDager private constructor(
     val fra: Personopplysninger,
     val mottaksdato: LocalDate,
@@ -61,6 +74,19 @@ internal class MottattDager private constructor(
             )
         }
     }
+}
+
+internal class MottattDagerOpphørt(
+    val fra: Personopplysninger,
+    val fraOgMed: LocalDate
+) : Melding {
+    override val mal = "OVERFORE_MOTTATT_DAGER_OPPHORT"
+    override val data = {
+        JSONObject().also { root ->
+            root.put("fraOgMed", "$fraOgMed")
+            root.put("fra", fra.somJSONObject())
+        }.toString()
+    }()
 }
 
 internal class TidligerePartner private constructor(

--- a/src/test/kotlin/no/nav/omsorgspenger/koronaoverføringer/formidling/OpphøreKoronaOverføringerMeldingTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/koronaoverføringer/formidling/OpphøreKoronaOverføringerMeldingTest.kt
@@ -1,0 +1,129 @@
+package no.nav.omsorgspenger.koronaoverføringer.formidling
+
+import no.nav.omsorgspenger.AktørId
+import no.nav.omsorgspenger.formidling.Meldingsbestilling
+import no.nav.omsorgspenger.koronaoverføringer.meldinger.OverføreKoronaOmsorgsdagerPersonopplysningerMelding
+import no.nav.omsorgspenger.personopplysninger.Enhet
+import no.nav.omsorgspenger.personopplysninger.Enhetstype
+import no.nav.omsorgspenger.personopplysninger.Navn
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+import org.skyscreamer.jsonassert.JSONAssert
+import java.time.LocalDate
+
+internal class OpphøreKoronaOverføringerMeldingTest {
+
+    @Test
+    fun `Ola opphører koronaoverføringene til kari - Olas melding`() {
+        val melding = GittDagerOpphørt(
+            til = kari,
+            fraOgMed = fraOgMed
+        )
+
+        val meldingsbestilling = Meldingsbestilling(
+            behovssekvensId = "01F1FH0HMEKAJDWGETFKPGGG6Z",
+            aktørId = ola.aktørId,
+            saksnummer = "OLA",
+            måBesvaresPerBrev = false,
+            melding = melding
+        )
+
+        @Language("JSON")
+        val forventetJson = """
+        {
+            "dokumentbestillingId": "01F1FH0HMEKAJDWGETFKPGGG6Z-1234",
+            "distribuere": false,
+            "dokumentMal": "KORONA_OVERFORE_GITT_DAGER_OPPHORT",
+            "avsenderApplikasjon": "OMSORGSPENGER_RAMMEMELDINGER",
+            "saksnummer": "OLA",
+            "aktørId": "1234",
+            "ytelseType": "OMSORGSPENGER",
+            "dokumentdata": {
+                "fraOgMed": "2021-03-21",
+                "til": {
+                    "navn": {
+                        "mellomnavn": "Olasson",
+                        "etternavn": "Nordmann",
+                        "fornavn": "Kari"
+                    },
+                    "fødselsdato": "2001-04-21"
+                }
+            },
+            "eksternReferanse": "01F1FH0HMEKAJDWGETFKPGGG6Z"
+        }
+        """.trimIndent()
+
+        meldingsbestilling.keyValue.second.jsonEquals(forventetJson)
+
+    }
+
+    @Test
+    fun `Ola opphører koronaoverføringene til kari - Karis melding`() {
+        val melding = MottattDagerOpphørt(
+            fra = ola,
+            fraOgMed = fraOgMed
+        )
+
+        val meldingsbestilling = Meldingsbestilling(
+            behovssekvensId = "01F1FH3XM9B0VWQR45E48EWV9V",
+            aktørId = kari.aktørId,
+            saksnummer = "KARI",
+            måBesvaresPerBrev = false,
+            melding = melding
+        )
+
+        @Language("JSON")
+        val forventetJson = """
+        {
+            "dokumentbestillingId": "01F1FH3XM9B0VWQR45E48EWV9V-5678",
+            "distribuere": false,
+            "dokumentMal": "KORONA_OVERFORE_MOTTATT_DAGER_OPPHORT",
+            "avsenderApplikasjon": "OMSORGSPENGER_RAMMEMELDINGER",
+            "saksnummer": "KARI",
+            "aktørId": "5678",
+            "ytelseType": "OMSORGSPENGER",
+            "dokumentdata": {
+                "fraOgMed": "2021-03-21",
+                "fra": {
+                    "navn": {
+                        "etternavn": "Nordmann",
+                        "fornavn": "Ola"
+                    },
+                    "fødselsdato": "2000-05-21"
+                }
+            },
+            "eksternReferanse": "01F1FH3XM9B0VWQR45E48EWV9V"
+        }
+        """.trimIndent()
+
+        meldingsbestilling.keyValue.second.jsonEquals(forventetJson)
+
+    }
+
+    private companion object {
+        val ola = personopplysninger(
+            navn = Navn(fornavn = "Ola", mellomnavn = null, etternavn = "Nordmann"),
+            aktørId = "1234",
+            fødselsdato = LocalDate.parse("2000-05-21")
+        )
+
+        val kari = personopplysninger(
+            navn = Navn(fornavn = "Kari", mellomnavn = "Olasson", etternavn = "Nordmann"),
+            aktørId = "5678",
+            fødselsdato = LocalDate.parse("2001-04-21")
+        )
+
+        val fraOgMed = LocalDate.parse("2021-03-21")
+
+        private fun personopplysninger(aktørId: AktørId, navn: Navn, fødselsdato: LocalDate) = OverføreKoronaOmsorgsdagerPersonopplysningerMelding.Personopplysninger(
+            navn = navn,
+            aktørId = aktørId,
+            fødselsdato = fødselsdato,
+            adressebeskyttet = false,
+            gjeldendeIdentitetsnummer = aktørId,
+            enhet = Enhet(enhetstype = Enhetstype.VANLIG, enhetsnummer = aktørId)
+        )
+        private fun String.jsonEquals(expected: String) = JSONAssert.assertEquals(expected, this, true)
+    }
+
+}

--- a/src/test/kotlin/no/nav/omsorgspenger/koronaoverføringer/rivers/KoronaoverføringerRapidVerktøy.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/koronaoverføringer/rivers/KoronaoverføringerRapidVerktøy.kt
@@ -27,14 +27,16 @@ internal object KoronaoverføringerRapidVerktøy {
         fraSaksnummer: Saksnummer = "foo",
         tilSaksnummer: Saksnummer = "bar",
         omsorgsdagerTattUtIÅr: Int = 0,
-        omsorgsdagerÅOverføre: Int = 10) : Pair<String, OverføreKoronaOmsorgsdagerLøsning> {
+        omsorgsdagerÅOverføre: Int = 10,
+        mottatt: ZonedDateTime = ZonedDateTime.now()) : Pair<String, OverføreKoronaOmsorgsdagerLøsning> {
 
         val (idStart, behovssekvens) = behovssekvensOverføreKoronaOmsorgsdager(
             fra = fra,
             til = til,
             omsorgsdagerTattUtIÅr = omsorgsdagerTattUtIÅr,
             omsorgsdagerÅOverføre = omsorgsdagerÅOverføre,
-            barn = barn
+            barn = barn,
+            mottatt = mottatt
         )
 
         sendTestMessage(behovssekvens)

--- a/src/test/kotlin/no/nav/omsorgspenger/koronaoverføringer/rivers/OpphøreKoronaOverføringerTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/koronaoverføringer/rivers/OpphøreKoronaOverføringerTest.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.time.Duration
 import java.time.LocalDate
+import java.time.ZonedDateTime
 import java.util.*
 import javax.sql.DataSource
 
@@ -54,7 +55,8 @@ internal class OpphøreKoronaOverføringerTest(
             tilSaksnummer = farSaksnummer,
             barn = listOf(barn),
             omsorgsdagerÅOverføre = 20,
-            omsorgsdagerTattUtIÅr = 7
+            omsorgsdagerTattUtIÅr = 7,
+            mottatt = Mottatt
         )
 
         rapid.reset()
@@ -65,7 +67,8 @@ internal class OpphøreKoronaOverføringerTest(
             tilSaksnummer = morSaksnummer,
             barn = listOf(barn),
             omsorgsdagerÅOverføre = 33,
-            omsorgsdagerTattUtIÅr = 0
+            omsorgsdagerTattUtIÅr = 0,
+            mottatt = Mottatt
         )
 
         rapid.reset()
@@ -76,7 +79,8 @@ internal class OpphøreKoronaOverføringerTest(
             tilSaksnummer = morSaksnummer,
             barn = listOf(barn),
             omsorgsdagerÅOverføre = 13,
-            omsorgsdagerTattUtIÅr = 0
+            omsorgsdagerTattUtIÅr = 0,
+            mottatt = Mottatt
         )
         rapid.reset()
 
@@ -152,6 +156,7 @@ internal class OpphøreKoronaOverføringerTest(
 
     private companion object {
         private val IDag = LocalDate.parse("2021-03-19")
+        private val Mottatt =  ZonedDateTime.parse("2021-03-19T16:00:00.000Z")
         private val OmEnUke = IDag.plusDays(1)
         private val Ut2021 = Periode(fom = IDag, tom = LocalDate.parse("2021-12-31"))
 

--- a/src/test/kotlin/no/nav/omsorgspenger/overføringer/formidling/OpphøreOverføringerMeldingTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/overføringer/formidling/OpphøreOverføringerMeldingTest.kt
@@ -1,0 +1,129 @@
+package no.nav.omsorgspenger.overføringer.formidling
+
+import no.nav.omsorgspenger.AktørId
+import no.nav.omsorgspenger.formidling.Meldingsbestilling
+import no.nav.omsorgspenger.overføringer.Personopplysninger
+import no.nav.omsorgspenger.personopplysninger.Enhet
+import no.nav.omsorgspenger.personopplysninger.Enhetstype
+import no.nav.omsorgspenger.personopplysninger.Navn
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+import org.skyscreamer.jsonassert.JSONAssert
+import java.time.LocalDate
+
+internal class OpphøreOverføringerMeldingTest {
+
+    @Test
+    fun `Ola opphører overføringene til kari - Olas melding`() {
+        val melding = GittDagerOpphørt(
+            til = kari,
+            fraOgMed = fraOgMed
+        )
+
+        val meldingsbestilling = Meldingsbestilling(
+            behovssekvensId = "01F1FH9YJVD3BCE3Y1244TDFFE",
+            aktørId = ola.aktørId,
+            saksnummer = "OLA",
+            måBesvaresPerBrev = false,
+            melding = melding
+        )
+
+        @Language("JSON")
+        val forventetJson = """
+        {
+            "dokumentbestillingId": "01F1FH9YJVD3BCE3Y1244TDFFE-1234",
+            "distribuere": false,
+            "dokumentMal": "OVERFORE_GITT_DAGER_OPPHORT",
+            "avsenderApplikasjon": "OMSORGSPENGER_RAMMEMELDINGER",
+            "saksnummer": "OLA",
+            "aktørId": "1234",
+            "ytelseType": "OMSORGSPENGER",
+            "dokumentdata": {
+                "fraOgMed": "2021-03-21",
+                "til": {
+                    "navn": {
+                        "mellomnavn": "Olasson",
+                        "etternavn": "Nordmann",
+                        "fornavn": "Kari"
+                    },
+                    "fødselsdato": "2001-04-21"
+                }
+            },
+            "eksternReferanse": "01F1FH9YJVD3BCE3Y1244TDFFE"
+        }
+        """.trimIndent()
+
+        meldingsbestilling.keyValue.second.jsonEquals(forventetJson)
+
+    }
+
+    @Test
+    fun `Ola opphører overføringene til kari - Karis melding`() {
+        val melding = MottattDagerOpphørt(
+            fra = ola,
+            fraOgMed = fraOgMed
+        )
+
+        val meldingsbestilling = Meldingsbestilling(
+            behovssekvensId = "01F1FHA8YS28KBXP1ZY98FTVPW",
+            aktørId = kari.aktørId,
+            saksnummer = "KARI",
+            måBesvaresPerBrev = false,
+            melding = melding
+        )
+
+        @Language("JSON")
+        val forventetJson = """
+        {
+            "dokumentbestillingId": "01F1FHA8YS28KBXP1ZY98FTVPW-5678",
+            "distribuere": false,
+            "dokumentMal": "OVERFORE_MOTTATT_DAGER_OPPHORT",
+            "avsenderApplikasjon": "OMSORGSPENGER_RAMMEMELDINGER",
+            "saksnummer": "KARI",
+            "aktørId": "5678",
+            "ytelseType": "OMSORGSPENGER",
+            "dokumentdata": {
+                "fraOgMed": "2021-03-21",
+                "fra": {
+                    "navn": {
+                        "etternavn": "Nordmann",
+                        "fornavn": "Ola"
+                    },
+                    "fødselsdato": "2000-05-21"
+                }
+            },
+            "eksternReferanse": "01F1FHA8YS28KBXP1ZY98FTVPW"
+        }
+        """.trimIndent()
+
+        meldingsbestilling.keyValue.second.jsonEquals(forventetJson)
+
+    }
+
+    private companion object {
+        val ola = personopplysninger(
+            navn = Navn(fornavn = "Ola", mellomnavn = null, etternavn = "Nordmann"),
+            aktørId = "1234",
+            fødselsdato = LocalDate.parse("2000-05-21")
+        )
+
+        val kari = personopplysninger(
+            navn = Navn(fornavn = "Kari", mellomnavn = "Olasson", etternavn = "Nordmann"),
+            aktørId = "5678",
+            fødselsdato = LocalDate.parse("2001-04-21")
+        )
+
+        val fraOgMed = LocalDate.parse("2021-03-21")
+
+        private fun personopplysninger(aktørId: AktørId, navn: Navn, fødselsdato: LocalDate) = Personopplysninger(
+            navn = navn,
+            aktørId = aktørId,
+            fødselsdato = fødselsdato,
+            adressebeskyttet = false,
+            gjeldendeIdentitetsnummer = aktørId,
+            enhet = Enhet(enhetstype = Enhetstype.VANLIG, enhetsnummer = aktørId)
+        )
+        private fun String.jsonEquals(expected: String) = JSONAssert.assertEquals(expected, this, true)
+    }
+
+}


### PR DESCRIPTION
- Kun definert meldingene m/tester, ikke tatt i bruk, så vil ikke sendes noen slike bestillinger enda.
- Fikser testen for opphøring av koronaoverføringer som var avhengig av now-tidspunkt