### PR TITLE
Update pgaudit logging settings in naiserator.yaml

### DIFF
--- a/nais/naiserator.yaml
+++ b/nais/naiserator.yaml
@@ -40,8 +40,10 @@ spec:
           - name: "cloudsql.enable_pgaudit"
             value: "on"
           - name: "pgaudit.log"
-            value: "all"
+            value: "read,write,ddl,role,function"
           - name: "pgaudit.log_parameter"
+            value: "on"
+          - name: "pgaudit.log_relation"
             value: "on"
         {{/if}}
         databases:


### PR DESCRIPTION
### Behov / Bakgrunn
NAIS anbefaler nå å sette pgaudit.log_relation = on for å dekke noen situasjoner hvor vi ikke auditlogger slik vi burde.

Slack: https://nav-it.slack.com/archives/C01DE3M9YBV/p1787214241846019
Nais docs: https://docs.nais.io/persistence/cloudsql/how-to/enable-auditing/

Vi oppdaget også at ved å bruke pgaudit.log = all blir det mye unødvendig logging. Etter sparring med Nais teamet endrer vi til å bruke read,write,ddl,role,function

### Løsning

Legger til pgaudit.log_relation = on
Endrer til pgaudit.log = read,write,ddl,role,function


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
